### PR TITLE
Add a simple molecule test of munin and munin-node roles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,14 @@
----
 sudo: required
 language: python
-python: "2.7"
 
-env:
-  - SITE=test.yml
-
-before_install:
-  - sudo apt-get update -qq
+services:
+  - docker
 
 install:
-  # Install Ansible.
-  - pip install ansible
-
-  # Add ansible.cfg to pick up roles path.
-  - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
+  - pip install ansible docker-py molecule
 
 script:
-  # Check the role/playbook's syntax.
-  - "ansible-playbook -i tests/inventory tests/$SITE --syntax-check"
-
-  # Run the role/playbook with ansible-playbook.
-  - "ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo"
-
-  # Run the role/playbook again, checking to make sure it's idempotent.
-  - >
-    ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo
-    | grep -q 'changed=0.*failed=0'
-    && (echo 'Idempotence test: pass' && exit 0)
-    || (echo 'Idempotence test: fail' && exit 1)
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+  requirements_file: tests/requirements.yml
+
+driver:
+  name: docker
+
+vagrant:
+  platforms:
+    - name: centos7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: munin
+
+docker:
+  containers:
+  - name: munin
+    image: centos/systemd
+    image_version: latest
+    privileged: True
+
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,32 @@
+---
+# An instance that monitors itself
+# This tests the munin and munin-node roles
+- hosts: all
+
+  pre_tasks:
+  - debug: var=hostvars
+  - name: Setup EPEL
+    yum:
+      pkg: epel-release
+      state: present
+
+  roles:
+  - role: openmicroscopy.munin-node
+  - role: ansible-role-munin
+    munin_hosts:
+    - name: "{{ ansible_hostname }}"
+      address: "127.0.0.1"
+
+  post_tasks:
+  - name: Install httpd
+    become: yes
+    yum:
+      name: httpd
+      state: present
+
+  - name: Start httpd
+    become: yes
+    service:
+      enabled: yes
+      name: httpd
+      state: started

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,1 @@
+- src: openmicroscopy.munin-node

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,27 @@
+import testinfra.utils.ansible_runner
+
+from glob import glob
+from os import remove
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+def test_services_running_and_enabled(Service):
+    service = Service('munin-node')
+    assert service.is_running
+    assert service.is_enabled
+
+
+# Munin relies on cron to gather stats at regular intervals bit cron isn't
+# enabled by default in docker, and in any case we don't want to wait.
+# Instead delete the generated files and manually run an update
+def test_gather_stats(Command, File, Sudo):
+    for f in glob('/var/www/html/munin/*.html'):
+        remove(f)
+
+    with Sudo('munin'):
+        out = Command.check_output('/usr/bin/munin-cron')
+    assert len(out) == 0
+
+    assert File('/var/www/html/munin/system-day.html').exists


### PR DESCRIPTION
Some issues have been reported in the IDR munin system, e.g. https://trello.com/c/4Sug86TS/168-munin-is-broken

This adds a simple `molecule` test to provide a baseline if someone else wants to try and fix it.