### PR TITLE
Allow to create cron file if not existing

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,7 @@
   lineinfile:
     dest: /etc/cron.d/munin
     state: "{{ munin_cron_job }}"
+    create: true
     regexp: "^\\*/5 \\* \\* \\* \\*"
     line: >-
       */5 * * * *     munin test -x /usr/bin/munin-cron && /usr/bin/munin-cron


### PR DESCRIPTION
The Molecule tests started failing with a `Destination does not exists` error -see  https://travis-ci.org/github/ome/ansible-roles/jobs/710978143

According to the [inlinefile](https://docs.ansible.com/ansible/2.6/modules/lineinfile_module.html) documentation, `create: true` should be set in conjunction with `inlinfile` to handle these cases. I expect it to be a no-op if `munin_cron_job` is set to `absent`